### PR TITLE
Moved persist column styles from table.columntoggle.css to table.skin.cs...

### DIFF
--- a/dist/bare/tablesaw.bare.css
+++ b/dist/bare/tablesaw.bare.css
@@ -1,4 +1,4 @@
-/*! Tablesaw - v1.0.0 - 2014-12-05
+/*! Tablesaw - v1.0.1 - 2014-12-09
 * https://github.com/filamentgroup/tablesaw
 * Copyright (c) 2014 Filament Group; Licensed MIT */
 
@@ -626,15 +626,6 @@ table.tablesaw {
 }
 
 @media only all {
-  .tablesaw-swipe .tablesaw-cell-persist {
-    border-right: 1px solid #e4e1de;
-  }
-
-  .tablesaw-swipe .tablesaw-cell-persist {
-    -webkit-box-shadow: 3px 0 4px -1px #e4e1de;
-    box-shadow: 3px 0 4px -1px #e4e1de;
-  }
-
   /* Unchecked manually: Always hide */
 
   .tablesaw-swipe th.tablesaw-cell-hidden,

--- a/dist/stackonly/tablesaw.stackonly.css
+++ b/dist/stackonly/tablesaw.stackonly.css
@@ -1,4 +1,4 @@
-/*! Tablesaw - v1.0.0 - 2014-12-05
+/*! Tablesaw - v1.0.1 - 2014-12-09
 * https://github.com/filamentgroup/tablesaw
 * Copyright (c) 2014 Filament Group; Licensed MIT */
 

--- a/dist/stackonly/tablesaw.stackonly.js
+++ b/dist/stackonly/tablesaw.stackonly.js
@@ -1,4 +1,4 @@
-/*! Tablesaw - v1.0.0 - 2014-12-05
+/*! Tablesaw - v1.0.1 - 2014-12-09
 * https://github.com/filamentgroup/tablesaw
 * Copyright (c) 2014 Filament Group; Licensed MIT */
 ;(function( $ ) {

--- a/dist/stackonly/tablesaw.stackonly.scss
+++ b/dist/stackonly/tablesaw.stackonly.scss
@@ -1,7 +1,7 @@
-/*! Tablesaw - v1.0.0 - 2014-12-05
+/*! Tablesaw - v1.0.1 - 2014-12-09
 * https://github.com/filamentgroup/tablesaw
 * Copyright (c) 2014 Filament Group; Licensed MIT */
-/*! Tablesaw - v1.0.0 - 2014-12-05
+/*! Tablesaw - v1.0.1 - 2014-12-09
 * https://github.com/filamentgroup/tablesaw
 * Copyright (c) 2014 Filament Group; Licensed MIT */
 

--- a/dist/tablesaw.css
+++ b/dist/tablesaw.css
@@ -1,4 +1,4 @@
-/*! Tablesaw - v1.0.0 - 2014-12-05
+/*! Tablesaw - v1.0.1 - 2014-12-09
 * https://github.com/filamentgroup/tablesaw
 * Copyright (c) 2014 Filament Group; Licensed MIT */
 
@@ -458,6 +458,17 @@ table.tablesaw thead td {
   }
 }
 
+@media only all {
+  .tablesaw-swipe .tablesaw-cell-persist {
+    border-right: 1px solid #e4e1de;
+  }
+
+  .tablesaw-swipe .tablesaw-cell-persist {
+    -webkit-box-shadow: 3px 0 4px -1px #e4e1de;
+    box-shadow: 3px 0 4px -1px #e4e1de;
+  }
+}
+
 /* Table rows have a gray bottom stroke by default */
 
 .tablesaw-stack tbody tr {
@@ -713,15 +724,6 @@ table.tablesaw thead td {
 }
 
 @media only all {
-  .tablesaw-swipe .tablesaw-cell-persist {
-    border-right: 1px solid #e4e1de;
-  }
-
-  .tablesaw-swipe .tablesaw-cell-persist {
-    -webkit-box-shadow: 3px 0 4px -1px #e4e1de;
-    box-shadow: 3px 0 4px -1px #e4e1de;
-  }
-
   /* Unchecked manually: Always hide */
 
   .tablesaw-swipe th.tablesaw-cell-hidden,

--- a/dist/tablesaw.js
+++ b/dist/tablesaw.js
@@ -1,4 +1,4 @@
-/*! Tablesaw - v1.0.0 - 2014-12-05
+/*! Tablesaw - v1.0.1 - 2014-12-09
 * https://github.com/filamentgroup/tablesaw
 * Copyright (c) 2014 Filament Group; Licensed MIT */
 ;(function( $ ) {

--- a/src/tables.columntoggle.css
+++ b/src/tables.columntoggle.css
@@ -117,13 +117,6 @@
 }
 
 @media only all {
-	.tablesaw-swipe .tablesaw-cell-persist {
-		border-right: 1px solid #e4e1de;
-	}
-	.tablesaw-swipe .tablesaw-cell-persist {
-		box-shadow: 3px 0 4px -1px #e4e1de;
-	}
-
 	/* Unchecked manually: Always hide */
 	.tablesaw-swipe th.tablesaw-cell-hidden,
 	.tablesaw-swipe td.tablesaw-cell-hidden,

--- a/src/tables.skin.css
+++ b/src/tables.skin.css
@@ -77,3 +77,12 @@ table.tablesaw thead td {
 		line-height: 2em;
 	}
 }
+
+@media only all {
+	.tablesaw-swipe .tablesaw-cell-persist {
+		border-right: 1px solid #e4e1de;
+	}
+	.tablesaw-swipe .tablesaw-cell-persist {
+		box-shadow: 3px 0 4px -1px #e4e1de;
+	}
+}


### PR DESCRIPTION
I updated the css files organization by moving some ".tablesaw-swipe .tablesaw-cell-persist" classes from tables.columntoggle.css to tables.skin.css.

This results in them being excluded from the tablesaw.bare.css file as one would hope for, making those tables more consistent.

This resolves the main code/appearance complaint form Issue #71 There are still documentation concerns in that issue which need to be addressed, but that can be done separately.
