### PR TITLE
Expanded Documentation for bare css option

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,13 @@ Check out any of the demos above for complete working examples.
 
 ### Using Bare TableSaw 
 
-If you would like the full functionality of the TableSaw plugin. but don't want the plugin's default table styles, use the `tablesaw.bare.css` file instead of the standard `tablesaw.css` file.
+Tablesaw is designed to be a drop-in solution, providing table styles as well as responsive table functionality.
+
+If you would like the full functionality of the TableSaw plugin. but the plugin's default table styles don't fit in with your project, use the `tablesaw.bare.css` file instead of the standard `tablesaw.css` file for a much lighter default style which is significantly easier to customize.
+
+To see what all TableSaw functionality looks like with this alternate stylesheet applied.
+
+* [Bare CSS Demo](http://filamentgroup.github.io/tablesaw/demo/bare.html)
 
 ## [Tests](http://filamentgroup.github.io/tablesaw/test/tablesaw.html)
 

--- a/demo/bare.html
+++ b/demo/bare.html
@@ -46,7 +46,7 @@
 	</div>
 	<div class="docs-main">
 		<h2>Bare Table</h2>
-		<p>A kitchen sink table demo using the bare css which does not include the tablesaw default table styles.</p>
+		<p>A demo which includes all TableSaw functionality, as per the <a href="kitchensink.html">Kitchen Sink</a> demo, but uses the "bare" css file. This file removes much of the default styling provided by the TableSaw plugin, allowing users to more easily customize table styles to better suit the needs of their projects..</p>
 		<table id="table2" class="tablesaw" data-tablesaw-mode="swipe" data-tablesaw-sortable data-tablesaw-sortable-switch data-tablesaw-minimap data-tablesaw-mode-switch>
 			<thead>
 				<tr>


### PR DESCRIPTION
As per the remaining notes on #71, I have expanded the documentation for the tablesaw.bare.css option to explain it in greater detail.

This has been done on both the readme and the bare css demo page itself. Only a sentence or two expansion in each place, I didn't want to write a treatise here, but hopefully this helps alleviate confusion such as that which prompted @PattyToland to open this issue in the first place.

One quick note, I don't see the explainer text on the current bare demo page as seen in the repo on the live one (http://filamentgroup.github.io/tablesaw/demo/bare.html). Is that something in the markup that needs resolving, or just something infrastructural pushing it live?

Thanks!
