### PR TITLE
Update `linear-gradient` direction syntax

### DIFF
--- a/dist/bare/tablesaw.bare.css
+++ b/dist/bare/tablesaw.bare.css
@@ -1,4 +1,4 @@
-/*! Tablesaw - v2.0.3 - 2016-05-02
+/*! Tablesaw - v2.0.3 - 2016-06-03
 * https://github.com/filamentgroup/tablesaw
 * Copyright (c) 2016 Filament Group; Licensed MIT */
 
@@ -51,7 +51,7 @@ table.tablesaw {
   width: 100%;
   /* Theming */
   background-image: -webkit-linear-gradient(top, rgba( 255,255,255,.1 ) 0%, rgba( 255,255,255,.1 ) 50%, rgba( 170,170,170,.1 ) 55%, rgba( 120,120,120,.15 ) 100%);
-  background-image: linear-gradient( top, rgba( 255,255,255,.1 ) 0%, rgba( 255,255,255,.1 ) 50%, rgba( 170,170,170,.1 ) 55%, rgba( 120,120,120,.15 ) 100% );
+  background-image: linear-gradient( to bottom, rgba( 255,255,255,.1 ) 0%, rgba( 255,255,255,.1 ) 50%, rgba( 170,170,170,.1 ) 55%, rgba( 120,120,120,.15 ) 100% );
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   box-sizing: border-box;
@@ -72,7 +72,7 @@ table.tablesaw {
 .tablesaw-enhanced .tablesaw-bar .btn:active {
   background-color: #ddd;
   background-image: -webkit-linear-gradient(top, rgba( 100,100,100,.35 ) 0%, rgba( 255,255,255,0 ) 70%);
-  background-image: linear-gradient( top, rgba( 100,100,100,.35 ) 0%, rgba( 255,255,255,0 ) 70% );
+  background-image: linear-gradient( to bottom, rgba( 100,100,100,.35 ) 0%, rgba( 255,255,255,0 ) 70% );
 }
 
 .tablesaw-enhanced .tablesaw-bar .btn:hover,

--- a/dist/stackonly/tablesaw.stackonly.css
+++ b/dist/stackonly/tablesaw.stackonly.css
@@ -1,4 +1,4 @@
-/*! Tablesaw - v2.0.3 - 2016-05-02
+/*! Tablesaw - v2.0.3 - 2016-06-03
 * https://github.com/filamentgroup/tablesaw
 * Copyright (c) 2016 Filament Group; Licensed MIT */
 

--- a/dist/stackonly/tablesaw.stackonly.js
+++ b/dist/stackonly/tablesaw.stackonly.js
@@ -1,4 +1,4 @@
-/*! Tablesaw - v2.0.3 - 2016-05-02
+/*! Tablesaw - v2.0.3 - 2016-06-03
 * https://github.com/filamentgroup/tablesaw
 * Copyright (c) 2016 Filament Group; Licensed MIT */
 /*

--- a/dist/stackonly/tablesaw.stackonly.scss
+++ b/dist/stackonly/tablesaw.stackonly.scss
@@ -1,7 +1,7 @@
-/*! Tablesaw - v2.0.3 - 2016-05-02
+/*! Tablesaw - v2.0.3 - 2016-06-03
 * https://github.com/filamentgroup/tablesaw
 * Copyright (c) 2016 Filament Group; Licensed MIT */
-/*! Tablesaw - v2.0.3 - 2016-05-02
+/*! Tablesaw - v2.0.3 - 2016-06-03
 * https://github.com/filamentgroup/tablesaw
 * Copyright (c) 2016 Filament Group; Licensed MIT */
 

--- a/dist/tablesaw-init.js
+++ b/dist/tablesaw-init.js
@@ -1,4 +1,4 @@
-/*! Tablesaw - v2.0.3 - 2016-05-02
+/*! Tablesaw - v2.0.3 - 2016-06-03
 * https://github.com/filamentgroup/tablesaw
 * Copyright (c) 2016 Filament Group; Licensed MIT */
 ;(function( $ ) {

--- a/dist/tablesaw.css
+++ b/dist/tablesaw.css
@@ -1,4 +1,4 @@
-/*! Tablesaw - v2.0.3 - 2016-05-02
+/*! Tablesaw - v2.0.3 - 2016-06-03
 * https://github.com/filamentgroup/tablesaw
 * Copyright (c) 2016 Filament Group; Licensed MIT */
 
@@ -51,7 +51,7 @@ table.tablesaw {
   width: 100%;
   /* Theming */
   background-image: -webkit-linear-gradient(top, rgba( 255,255,255,.1 ) 0%, rgba( 255,255,255,.1 ) 50%, rgba( 170,170,170,.1 ) 55%, rgba( 120,120,120,.15 ) 100%);
-  background-image: linear-gradient( top, rgba( 255,255,255,.1 ) 0%, rgba( 255,255,255,.1 ) 50%, rgba( 170,170,170,.1 ) 55%, rgba( 120,120,120,.15 ) 100% );
+  background-image: linear-gradient( to bottom, rgba( 255,255,255,.1 ) 0%, rgba( 255,255,255,.1 ) 50%, rgba( 170,170,170,.1 ) 55%, rgba( 120,120,120,.15 ) 100% );
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   box-sizing: border-box;
@@ -72,7 +72,7 @@ table.tablesaw {
 .tablesaw-enhanced .tablesaw-bar .btn:active {
   background-color: #ddd;
   background-image: -webkit-linear-gradient(top, rgba( 100,100,100,.35 ) 0%, rgba( 255,255,255,0 ) 70%);
-  background-image: linear-gradient( top, rgba( 100,100,100,.35 ) 0%, rgba( 255,255,255,0 ) 70% );
+  background-image: linear-gradient( to bottom, rgba( 100,100,100,.35 ) 0%, rgba( 255,255,255,0 ) 70% );
 }
 
 .tablesaw-enhanced .tablesaw-bar .btn:hover,

--- a/dist/tablesaw.js
+++ b/dist/tablesaw.js
@@ -1,4 +1,4 @@
-/*! Tablesaw - v2.0.3 - 2016-05-02
+/*! Tablesaw - v2.0.3 - 2016-06-03
 * https://github.com/filamentgroup/tablesaw
 * Copyright (c) 2016 Filament Group; Licensed MIT */
 /*

--- a/src/tables.toolbar.css
+++ b/src/tables.toolbar.css
@@ -35,7 +35,7 @@
 	width: 100%;
 
 	/* Theming */
-	background-image: linear-gradient( top, rgba( 255,255,255,.1 ) 0%, rgba( 255,255,255,.1 ) 50%, rgba( 170,170,170,.1 ) 55%, rgba( 120,120,120,.15 ) 100% );
+	background-image: linear-gradient( to bottom, rgba( 255,255,255,.1 ) 0%, rgba( 255,255,255,.1 ) 50%, rgba( 170,170,170,.1 ) 55%, rgba( 120,120,120,.15 ) 100% );
 
 	-webkit-appearance: none !important;
 	-moz-appearance: none !important;
@@ -56,7 +56,7 @@
 /* Default radio/checkbox styling horizonal controlgroups. */
 .tablesaw-enhanced .tablesaw-bar .btn:active {
 	background-color: #ddd;
-	background-image: linear-gradient( top, rgba( 100,100,100,.35 ) 0%, rgba( 255,255,255,0 ) 70% );
+	background-image: linear-gradient( to bottom, rgba( 100,100,100,.35 ) 0%, rgba( 255,255,255,0 ) 70% );
 }
 .tablesaw-enhanced .tablesaw-bar .btn:hover,
 .tablesaw-enhanced .tablesaw-bar .btn:focus {
@@ -138,7 +138,7 @@
 
 .tablesaw-bar .btn-select:after {
 	background: none;
-	background-repeat: no-repeat; 
+	background-repeat: no-repeat;
 	background-position: .25em .45em;
 	content: "\25bc";
 	font-size: .55em;


### PR DESCRIPTION
When running the test suite for a project that uses Tablesaw, I see the following warnings:

![image](https://cloud.githubusercontent.com/assets/190916/15792458/6336eec4-29ab-11e6-8177-3c2a01a1f689.png)

I've seen these warnings for a few weeks now, and I've traced them back to Tablesaw. The `src/tables.toolbar.css` stylesheet contained references to an outdated linear gradient direction syntax (ex: `linear-gradient( top, #fff, #000 );`). 

This commit updates those references to the current syntax (`to bottom` instead of `top`).