### PR TITLE
Add "main" entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "test": "./node_modules/.bin/grunt travis"
   },
+  "main": "dist/tablesaw.js",
   "dependencies": {
     "jquery": "^3.1.0",
     "respond.js": "^1.4.2",


### PR DESCRIPTION
Now that this plugin has a UMD, let's add a "main" entry so that it can be conveniently imported.