### PR TITLE
update README.md with ES6 module import instructions for jQuery version

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,23 @@ All of the above options combined into a single table.
 
 </details>
 
-Don’t forget to add your table markup! For a stack table, this is how it’d look: 
+<details open>
+<summary>or Tablesaw (jQuery ES6 module import)</summary>
+
+```html
+<link rel="stylesheet" href="tablesaw.css">
+```
+
+```javascript
+<!-- load your own jQuery -->
+import tablesaw from 'tablesaw/dist/tablesaw.jquery.js',
+
+tablesaw();
+```
+
+</details>
+
+Don’t forget to add your table markup! For a stack table, this is how it’d look:
 
 ```html
 <table class="tablesaw tablesaw-stack" data-tablesaw-mode="stack">
@@ -271,6 +287,20 @@ As shown above, we provide a Stack-mode-only package of Tablesaw. It’s a bareb
 ```
 
 </details>
+
+<details open>
+<summary>or Stack-only Tablesaw (jQuery ES6 module import)</summary>
+
+```html
+<link rel="stylesheet" href="tablesaw.css">
+```
+
+```javascript
+<!-- load your own jQuery -->
+import tablesaw from 'tablesaw/dist/stackonly/tablesaw.stackonly.jquery.js',
+
+tablesaw();
+```
 
 And then:
 


### PR DESCRIPTION
The Tablesaw jQuery version has a UMD module definition that exports a function that has to be explicitly called once imported. I added this to the README.md.
