### PR TITLE
Add support initially hiding or showing columns

### DIFF
--- a/src/tables.columntoggle.js
+++ b/src/tables.columntoggle.js
@@ -44,7 +44,9 @@
 			$popup,
 			$menu,
 			$btnContain,
-			self = this;
+			self = this,
+			initiallyHidden = [],
+			initiallyShown = [];
 
 		this.$table.addClass( this.classes.columnToggleTable );
 
@@ -60,6 +62,7 @@
 		$( this.headers ).not( "td" ).each( function() {
 			var $this = $( this ),
 				priority = $this.attr("data-tablesaw-priority"),
+				hidden = $this.data("tablesaw-hidden"),
 				$cells = self.$getCells( this );
 
 			if( priority && priority !== "persist" ) {
@@ -71,6 +74,11 @@
 					.data( "tablesaw-header", this );
 
 				hasNonPersistentHeaders = true;
+				if (hidden === true) {
+					initiallyHidden.push(this);
+				} else if (hidden === false) {
+					initiallyShown.push(this);
+				}
 			}
 		});
 
@@ -138,6 +146,17 @@
 			self.refreshToggle();
 		});
 
+
+		$(initiallyHidden).each( function ( idx, th ) {
+			self.$getCells( th )
+				.toggleClass( "tablesaw-cell-hidden", true )
+				.toggleClass( "tablesaw-cell-visible", false );
+		});
+		$(initiallyShown).each( function ( idx, th ) {
+			self.$getCells( th )
+				.toggleClass( "tablesaw-cell-hidden", false )
+				.toggleClass( "tablesaw-cell-visible", true );
+		});
 		this.refreshToggle();
 	};
 

--- a/src/tables.columntoggle.js
+++ b/src/tables.columntoggle.js
@@ -64,6 +64,17 @@
 				priority = $this.attr("data-tablesaw-priority"),
 				hidden = $this.data("tablesaw-hidden"),
 				$cells = self.$getCells( this );
+			if (hidden === undefined) {
+				// This secondary attribute check is only necessary when using shoestring, not jQuery.
+				hidden = $this.attr("data-tablesaw-hidden");
+				if (hidden !== undefined) {
+					if (hidden === "true") {
+						hidden = true;
+					} else if (hidden === "false") {
+						hidden = false;
+					}
+				}
+			}
 
 			if( priority && priority !== "persist" ) {
 				$cells.addClass( self.classes.priorityPrefix + priority );
@@ -149,13 +160,13 @@
 
 		$(initiallyHidden).each( function ( idx, th ) {
 			self.$getCells( th )
-				.toggleClass( "tablesaw-cell-hidden", true )
-				.toggleClass( "tablesaw-cell-visible", false );
+				.addClass( "tablesaw-cell-hidden" )
+				.removeClass( "tablesaw-cell-visible" );
 		});
 		$(initiallyShown).each( function ( idx, th ) {
 			self.$getCells( th )
-				.toggleClass( "tablesaw-cell-hidden", false )
-				.toggleClass( "tablesaw-cell-visible", true );
+				.removeClass( "tablesaw-cell-hidden" )
+				.addClass( "tablesaw-cell-visible" );
 		});
 		this.refreshToggle();
 	};

--- a/test/tablesaw_jquery.html
+++ b/test/tablesaw_jquery.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Tablesaw Test Suite</title>
+  <link rel="stylesheet" href="../dist/dependencies/qunit.css">
+  <link rel="stylesheet" href="../dist/tablesaw.css">
+
+  <script src="../dist/dependencies/jquery.js"></script>
+  <script src="../dist/dependencies/qunit.js"></script>
+  <!-- The shoestring-based tests assume that jquery has been reassigned
+       to window.$jQ, doing something similar here to ensure that the
+       same tests can be used in both instances. -->
+  <script>
+    window.$jQ = $;
+  </script>
+
+  <script src="../dist/tablesaw.jquery.js"></script>
+  <script src="tablesaw_test.js"></script>
+</head>
+<body>
+  <div id="qunit"></div>
+  <div id="qunit-fixture"></div>
+</body>
+</html>

--- a/test/tablesaw_test.js
+++ b/test/tablesaw_test.js
@@ -428,4 +428,92 @@
 		assert.strictEqual( $secondRowLastCell.is( '.tablesaw-cell-hidden' ), true, 'Cell 1,4 is hidden after checkbox unchecked' );
 	});
 
+	QUnit.module ('tablesaw initially toggled columns', {
+		beforeEach: function() {
+			var toggledHtml = [
+				'<table data-tablesaw-mode="columntoggle" data-tablesaw-minimap data-tablesaw-no-labels>',
+				'<thead>',
+					'<tr>',
+						'<th data-tablesaw-priority="1" data-tablesaw-hidden="true">Header 1</th>',
+						'<th data-tablesaw-priority="2" data-tablesaw-hidden="false">Header 2</th>',
+						'<th data-tablesaw-priority="5">Header 3</th>',
+						'<th data-tablesaw-priority="6">Header 4</th>',
+					'</tr>',
+				'</thead>',
+				'<tbody>',
+					'<tr>',
+						'<td>Body Row 1</td>',
+						'<td>1</td>',
+						'<td>This column text is designed to make the columns really wide.</td>',
+						'<td>This column text is designed to make the columns really wide.</td>',
+					'</tr>',
+					'<tr><td>Body Row 2</td><td>2</td><td>2</td><td>2</td></tr>',
+					'<tr><td>Body Row 3</td><td>3</td><td>A</td><td>A</td></tr>',
+				'</tbody>',
+				'</table>'].join('');
+			$fixture.html( toggledHtml );
+			$table = $fixture.find( 'table' );
+			$( document ).trigger( 'enhance.tablesaw' );
+		}
+	});
+
+	QUnit.test('Are columns initially hidden or visible', function( assert ) {
+		var $firstRowCell1 = $table.find( 'tbody tr' ).eq( 0 ).find( 'td' ).eq( 0 );
+		var $firstRowCell2 = $table.find( 'tbody tr' ).eq( 0 ).find( 'td' ).eq( 1 );
+
+		assert.strictEqual( $firstRowCell1.is( '.tablesaw-cell-hidden' ), true, 'First cell is initially hidden.' );
+		assert.strictEqual( $firstRowCell1.is( '.tablesaw-cell-visible' ), false, 'First cell is initially not visible.' );
+		assert.strictEqual( $firstRowCell2.is( '.tablesaw-cell-hidden' ), false, 'Second cell is initially not hidden.' );
+		assert.strictEqual( $firstRowCell2.is( '.tablesaw-cell-visible' ), true, 'Second cell is initially visible.' );
+
+		var $toggleButton = $table.prev().find( '.tablesaw-columntoggle-btn' ).trigger( 'click' )
+			.next().find( 'input[type="checkbox"]' ).first();
+		assert.strictEqual ( $toggleButton[0].checked, false, "First checkbox should've been turned off." );
+		$toggleButton.trigger( 'click' );
+
+		// close dialog
+		$( '.tablesaw-columntoggle-popup .close' ).trigger( "click" );
+
+		assert.strictEqual( $firstRowCell1.is( '.tablesaw-cell-hidden' ), false, 'First cell should no longer be hidden.' );
+		assert.strictEqual( $firstRowCell1.is( '.tablesaw-cell-visible' ), true, 'First cell should be visible.' );
+
+		var $middlecheck = $($table.prev().find( '.tablesaw-columntoggle-btn' ).trigger( 'click' )
+			.next().find( 'input[type="checkbox"]' )[1]);
+		assert.strictEqual ( $middlecheck[0].checked, true, "Second checkbox should've been turned on." );
+		$middlecheck.trigger( 'click' );
+
+		assert.strictEqual( $firstRowCell2.is( '.tablesaw-cell-hidden' ), true, 'Second cell should be hidden.' );
+		assert.strictEqual( $firstRowCell2.is( '.tablesaw-cell-visible' ), false, 'Second cell should no longer be visible.' );
+	});
+
+	QUnit.test('Is minimap correct', function( assert ) {
+		var $minimap = $table.prev().find( '.minimap' );
+		assert.ok( $minimap.length, 'Minimap exists.' );
+		assert.strictEqual( $minimap.find( 'li' ).first().is( '.tablesaw-advance-dots-hide' ), true, 'First minimap dot is hidden.' );
+		assert.strictEqual( $($minimap.find( 'li' )[1]).is( '.tablesaw-advance-dots-hide' ), false, 'Second minimap dot is visible.' );
+	});
+
+	QUnit.test('Shoestring data test', function( assert ) {
+		var $firstRowCell1 = $table.find( 'tbody tr' ).eq( 0 ).find( 'td' ).eq( 0 );
+		assert.strictEqual( $firstRowCell1.is( '.tablesaw-cell-hidden' ), true, 'First cell is initially hidden.' );
+		assert.strictEqual( $firstRowCell1.is( '.tablesaw-cell-visible' ), false, 'First cell is initially not visible.' );
+		$table.tablesaw().data('tablesaw').destroy();
+		$table.find( 'thead tr' ).eq( 0 ).find( 'th' ).eq( 0).data('tablesaw-hidden', false);
+		$table.tablesaw();
+		assert.strictEqual( $firstRowCell1.is( '.tablesaw-cell-hidden' ), false, 'First cell is no longer initially hidden.' );
+		assert.strictEqual( $firstRowCell1.is( '.tablesaw-cell-visible' ), true, 'First cell is no longer initially not visible.' );
+
+		var $toggleButton = $table.prev().find( '.tablesaw-columntoggle-btn' ).trigger( 'click' )
+				.next().find( 'input[type="checkbox"]' ).first();
+		assert.strictEqual ( $toggleButton[0].checked, true, "First checkbox should've been turned on." );
+		$toggleButton.trigger( 'click' );
+
+		// close dialog
+		$( '.tablesaw-columntoggle-popup .close' ).trigger( "click" );
+
+		assert.strictEqual( $firstRowCell1.is( '.tablesaw-cell-hidden' ), true, 'First cell should be hidden.' );
+		assert.strictEqual( $firstRowCell1.is( '.tablesaw-cell-visible' ), false, 'First cell should no longer be visible.' );
+	});
+
+
 }( window.shoestring || window.jQuery || window.$jQ ));


### PR DESCRIPTION
I needed to preserve the shown/hidden state of columns when using column toggle mode across table refreshes. This PR does so by adding a new data attribute, `data-tablesaw-hidden`. When set to `true` it will force the column to be initially hidden. When set to `false` it will ensure that the column is initially visible.

Other users have requested similar functionality (see #214 for example). This provides that functionality in a round-about way. I'm not sure if the data attribute method is the best approach to solve this issue, but it seemed to be in the same spirit as the rest of the declarative  configuration attributes that Tablesaw employs.

These changes were originally made against the 2.x series and thus relied upon some jQuery functionality that hasn't been duplicated in Shoestring. I added a second test HTML file that executes the full test suite against the jQuery-version of the code. The final commit in the branch adjusts the code to be compatible with Shoestring.
