### PR TITLE
Fix for Column Toggle with Shoestring

### DIFF
--- a/src/tables.columntoggle.js
+++ b/src/tables.columntoggle.js
@@ -67,7 +67,8 @@
 
 				$("<label><input type='checkbox' checked>" + $this.text() + "</label>" )
 					.appendTo( $menu )
-					.children( 0 )
+					.children()
+					.first()
 					.data( "tablesaw-header", this );
 
 				hasNonPersistentHeaders = true;


### PR DESCRIPTION
Shoestring does not support arguments being passed to the `children` function, which throws an error when using a Column Toggle Table

https://github.com/filamentgroup/shoestring/blob/55af278bead9468432b3ada49c8698203b34676d/src/dom/children.js#L12
