### PR TITLE
Allows data-tablesaw-no-labels to be added to a <td>

### DIFF
--- a/demo/labelless.html
+++ b/demo/labelless.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>TableSaw Stack Table with Labelless Table, Row and Cell</title>
+
+	<link rel="stylesheet" href="../dist/stackonly/tablesaw.stackonly.css">
+	<link rel="stylesheet" href="demo.css">
+	<link rel="stylesheet" href="//filamentgroup.github.io/demo-head/demohead.css">
+
+	<script src="../dist/stackonly/tablesaw.stackonly.js"></script>
+	<script src="../dist/tablesaw-init.js"></script>
+	<script src="//filamentgroup.github.io/demo-head/loadfont.js"></script>
+</head>
+<body>
+	<div class="demo-header">
+		<div class="company">
+			<img src="http://filamentgroup.com/images/fg-logo-positive-sm-crop.png">
+		</div>
+		<div class="details">
+			<h1 class="description-container">Demo of <span class="repo-name">Tablesaw</span>
+				<span class="description">A group of plugins for responsive tables.</span>
+			</h1>
+			<ul class="outbound-links">
+				<li><a href="https://github.com/filamentgroup/tablesaw">Code</a></li>
+				<li><a href="https://github.com/filamentgroup/tablesaw/issues">Issues</a></li>
+			</ul>
+		</div>
+	</div>
+	<div class="nav-container">
+		<div class="docs-globalnav">
+			<nav class="docs-nav">
+			<a href="kitchensink.html">Kitchen Sink</a>
+			<a href="modeswitch.html">Mode Switch</a>
+			<a href="sort.html">Sortable</a>
+			<a href="stack.html">Stack</a>
+			<a href="stackonly.html" class="current">Stack Only</a>
+			<a href="swipe.html">Swipe Table</a>
+			<a href="toggle.html">Toggle</a>
+			<a href="checkall.html">Check All</a>
+			</nav>
+		</div>
+	</div>
+	<div class="docs-main">
+		<h2>(Only the) Stack Table with Labelless Table, Row and Cell</h2>
+		<p>The following is an example of a table with <i>data-tablesaw-no-labels</i> applied to the whole table.</p>
+		<table class="tablesaw tablesaw-stack" data-tablesaw-mode="stack" data-tablesaw-no-labels>
+			<thead>
+				<tr>
+					<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="persist">Movie Title</th>
+					<th scope="col" data-tablesaw-sortable-col data-tablesaw-sortable-default-col data-tablesaw-priority="3">Rank</th>
+					<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="2">Year</th>
+					<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="1"><abbr title="Rotten Tomato Rating">Rating</abbr></th>
+					<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="4">Gross</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td class="title"><a href="http://en.wikipedia.org/wiki/Avatar_(2009_film)">Avatar</a></td>
+					<td>1</td>
+					<td>2009</td>
+					<td>83%</td>
+					<td>$2.7B</td>
+				</tr>
+				<tr>
+					<td class="title"><a href="http://en.wikipedia.org/wiki/Titanic_(1997_film)">Titanic</a></td>
+					<td>2</td>
+					<td>1997</td>
+					<td>88%</td>
+					<td>$2.1B</td>
+				</tr>
+				<tr>
+					<td class="title"><a href="http://en.wikipedia.org/wiki/The_Avengers_(2012_film)">The Avengers</a></td>
+					<td>3</td>
+					<td>2012</td>
+					<td>92%</td>
+					<td>$1.5B</td>
+				</tr>
+			</tbody>
+		</table>
+
+		<hr style="margin: 20px 0;"/>
+		<p>The following is an example of a table with <i>data-tablesaw-no-labels</i> applied to the first row as well as the first cell (td) on the second row.</p>
+		<table class="tablesaw tablesaw-stack" data-tablesaw-mode="stack">
+			<thead>
+				<tr >
+					<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="persist">Movie Title</th>
+					<th scope="col" data-tablesaw-sortable-col data-tablesaw-sortable-default-col data-tablesaw-priority="3">Rank</th>
+					<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="2">Year</th>
+					<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="1"><abbr title="Rotten Tomato Rating">Rating</abbr></th>
+					<th scope="col" data-tablesaw-sortable-col data-tablesaw-priority="4">Gross</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr data-tablesaw-no-labels>
+					<td class="title"><a href="http://en.wikipedia.org/wiki/Avatar_(2009_film)">Avatar</a></td>
+					<td>1</td>
+					<td>2009</td>
+					<td>83%</td>
+					<td>$2.7B</td>
+				</tr>
+				<tr>
+					<td class="title" data-tablesaw-no-labels><a href="http://en.wikipedia.org/wiki/Titanic_(1997_film)">Titanic</a></td>
+					<td>2</td>
+					<td>1997</td>
+					<td>88%</td>
+					<td>$2.1B</td>
+				</tr>
+				<tr>
+					<td class="title"><a href="http://en.wikipedia.org/wiki/The_Avengers_(2012_film)">The Avengers</a></td>
+					<td>3</td>
+					<td>2012</td>
+					<td>92%</td>
+					<td>$1.5B</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+
+</body>
+</html>

--- a/dist/stackonly/tablesaw.stackonly.jquery.js
+++ b/dist/stackonly/tablesaw.stackonly.jquery.js
@@ -569,7 +569,7 @@ if (Tablesaw.mustard) {
 			.filter(function() {
 				return (
 					!$(this)
-					  .is("[" + attrs.labelless + "]") &&
+					  	.is("[" + attrs.labelless + "]") &&
 					!$(this)
 						.closest("tr")
 						.is("[" + attrs.labelless + "]") &&

--- a/dist/stackonly/tablesaw.stackonly.jquery.js
+++ b/dist/stackonly/tablesaw.stackonly.jquery.js
@@ -569,6 +569,8 @@ if (Tablesaw.mustard) {
 			.filter(function() {
 				return (
 					!$(this)
+					  .is("[" + attrs.labelless + "]") &&
+					!$(this)
 						.closest("tr")
 						.is("[" + attrs.labelless + "]") &&
 					(!self.hideempty || !!$(this).html())

--- a/dist/stackonly/tablesaw.stackonly.js
+++ b/dist/stackonly/tablesaw.stackonly.js
@@ -3,7 +3,7 @@
 * Copyright (c) 2018 Filament Group; Licensed MIT */
 /*! Shoestring - v2.0.0 - 2017-02-14
 * http://github.com/filamentgroup/shoestring/
-* Copyright (c) 2017 Scott Jehl, Filament Group, Inc; Licensed MIT & GPLv2 */ 
+* Copyright (c) 2017 Scott Jehl, Filament Group, Inc; Licensed MIT & GPLv2 */
 (function( factory ) {
 	if( typeof define === 'function' && define.amd ) {
 			// AMD. Register as an anonymous module.
@@ -934,7 +934,7 @@
 	 * @this shoestring
 	 */
 	shoestring.fn.next = function(){
-		
+
 		var result = [];
 
 		// TODO need to implement map
@@ -1050,7 +1050,7 @@
 	 * @this shoestring
 	 */
 	shoestring.fn.prev = function(){
-		
+
 		var result = [];
 
 		// TODO need to implement map
@@ -1090,7 +1090,7 @@
 	 * @this shoestring
 	 */
 	shoestring.fn.prevAll = function(){
-		
+
 		var result = [];
 
 		this.each(function() {
@@ -1213,7 +1213,7 @@
 	 * @this shoestring
 	 */
 	shoestring.fn.siblings = function(){
-		
+
 		if( !this.length ) {
 			return shoestring( [] );
 		}
@@ -1271,7 +1271,7 @@
 	 * @this shoestring
 	 */
 	shoestring.fn.text = function() {
-		
+
 		return getText( this );
 	};
 
@@ -1529,7 +1529,7 @@
 
 	shoestring.fn.on = shoestring.fn.bind;
 
-	
+
 
 
 	/**
@@ -1542,7 +1542,7 @@
 	 */
 	shoestring.fn.unbind = function( event, callback ){
 
-		
+
 		var evts = event ? event.split( " " ) : [];
 
 		return this.each(function(){
@@ -2269,6 +2269,8 @@ if (Tablesaw.mustard) {
 			})
 			.filter(function() {
 				return (
+					!$(this)
+					  .is("[" + attrs.labelless + "]") &&
 					!$(this)
 						.closest("tr")
 						.is("[" + attrs.labelless + "]") &&

--- a/dist/stackonly/tablesaw.stackonly.js
+++ b/dist/stackonly/tablesaw.stackonly.js
@@ -2270,7 +2270,7 @@ if (Tablesaw.mustard) {
 			.filter(function() {
 				return (
 					!$(this)
-					  .is("[" + attrs.labelless + "]") &&
+					  	.is("[" + attrs.labelless + "]") &&
 					!$(this)
 						.closest("tr")
 						.is("[" + attrs.labelless + "]") &&

--- a/dist/tablesaw.js
+++ b/dist/tablesaw.js
@@ -3,7 +3,7 @@
 * Copyright (c) 2018 Filament Group; Licensed MIT */
 /*! Shoestring - v2.0.0 - 2017-02-14
 * http://github.com/filamentgroup/shoestring/
-* Copyright (c) 2017 Scott Jehl, Filament Group, Inc; Licensed MIT & GPLv2 */ 
+* Copyright (c) 2017 Scott Jehl, Filament Group, Inc; Licensed MIT & GPLv2 */
 (function( factory ) {
 	if( typeof define === 'function' && define.amd ) {
 			// AMD. Register as an anonymous module.
@@ -934,7 +934,7 @@
 	 * @this shoestring
 	 */
 	shoestring.fn.next = function(){
-		
+
 		var result = [];
 
 		// TODO need to implement map
@@ -1050,7 +1050,7 @@
 	 * @this shoestring
 	 */
 	shoestring.fn.prev = function(){
-		
+
 		var result = [];
 
 		// TODO need to implement map
@@ -1090,7 +1090,7 @@
 	 * @this shoestring
 	 */
 	shoestring.fn.prevAll = function(){
-		
+
 		var result = [];
 
 		this.each(function() {
@@ -1213,7 +1213,7 @@
 	 * @this shoestring
 	 */
 	shoestring.fn.siblings = function(){
-		
+
 		if( !this.length ) {
 			return shoestring( [] );
 		}
@@ -1271,7 +1271,7 @@
 	 * @this shoestring
 	 */
 	shoestring.fn.text = function() {
-		
+
 		return getText( this );
 	};
 
@@ -1529,7 +1529,7 @@
 
 	shoestring.fn.on = shoestring.fn.bind;
 
-	
+
 
 
 	/**
@@ -1542,7 +1542,7 @@
 	 */
 	shoestring.fn.unbind = function( event, callback ){
 
-		
+
 		var evts = event ? event.split( " " ) : [];
 
 		return this.each(function(){
@@ -2269,6 +2269,8 @@ if (Tablesaw.mustard) {
 			})
 			.filter(function() {
 				return (
+					!$(this)
+					  .is("[" + attrs.labelless + "]") &&
 					!$(this)
 						.closest("tr")
 						.is("[" + attrs.labelless + "]") &&

--- a/dist/tablesaw.js
+++ b/dist/tablesaw.js
@@ -2270,7 +2270,7 @@ if (Tablesaw.mustard) {
 			.filter(function() {
 				return (
 					!$(this)
-					  .is("[" + attrs.labelless + "]") &&
+					  	.is("[" + attrs.labelless + "]") &&
 					!$(this)
 						.closest("tr")
 						.is("[" + attrs.labelless + "]") &&

--- a/src/tables.stack.js
+++ b/src/tables.stack.js
@@ -48,7 +48,7 @@
 			.filter(function() {
 				return (
 					!$(this)
-					  .is("[" + attrs.labelless + "]") &&
+					  	.is("[" + attrs.labelless + "]") &&
 					!$(this)
 						.closest("tr")
 						.is("[" + attrs.labelless + "]") &&

--- a/src/tables.stack.js
+++ b/src/tables.stack.js
@@ -48,6 +48,8 @@
 			.filter(function() {
 				return (
 					!$(this)
+					  .is("[" + attrs.labelless + "]") &&
+					!$(this)
 						.closest("tr")
 						.is("[" + attrs.labelless + "]") &&
 					(!self.hideempty || !!$(this).html())


### PR DESCRIPTION
I encountered a scenario where a table had a colum which contained a URL and I didn't need a `URL` label to be displayed alongside it.

A row level `data-tablesaw-no-labels` would remove the labels for every `td` in that row and I only needed a label removed for a specific `td`.

Hence, I tweaked some code to allow a `td` to have its label suppressed.

I included a `labelless.html` page as an example of what I mean.

I'm unfamiliar with QUnit (or js testing frameworks for that matter).  Although I'm interested in learning it I don't have the capacity at the moment.  I figured this PR was more productive than raising an issue.

It also responds to this issue that was raised previously: https://github.com/filamentgroup/tablesaw/issues/144