### PR TITLE
Fix HTML injection in column toggle.

### DIFF
--- a/src/tables.columntoggle.js
+++ b/src/tables.columntoggle.js
@@ -101,7 +101,7 @@
 			if (priority && priority !== "persist") {
 				$cells.addClass(self.classes.priorityPrefix + priority);
 
-				$(cfg.getColumnToggleLabelTemplate($this.text()))
+				$(cfg.getColumnToggleLabelTemplate($this.html()))
 					.appendTo($menu)
 					.find('input[type="checkbox"]')
 					.data("tablesaw-header", this);


### PR DESCRIPTION
The column toggle element gets the label as text an writes the label as HTML.

When using <script>alert("Hacked");</script> as column label (in HTML escaped form),
the code gets executed by the column toggle component.

As the column label might be user generated content, this could lead to XSS attacks.



If youi need an example, I could create one.