### PR TITLE
Fix stacked table on mobile for screen readers (A11y fix)

### DIFF
--- a/src/tables.stack-default-breakpoint.css
+++ b/src/tables.stack-default-breakpoint.css
@@ -38,6 +38,9 @@
 
 /* Media query to show as a standard table at 560px (35em x 16px) or wider */
 @media (min-width: 40em) {
+  .tablesaw-stack {
+    display: table;
+  }
   .tablesaw-stack tr {
     display: table-row;
   }

--- a/src/tables.stack.css
+++ b/src/tables.stack.css
@@ -13,6 +13,7 @@
 	/* Show the table cells as a block level element */
 	.tablesaw-stack {
 		clear: both;
+		display: block;
 	}
 	.tablesaw-stack td,
 	.tablesaw-stack th {


### PR DESCRIPTION
Set the mobile table element to block display. 

This CSS change allows screen readers to access the mobile table content, which has already been changed to a block display.
