### PR TITLE
Improve accessibility of table headers (Fixes #385)

### DIFF
--- a/dist/stackonly/tablesaw.stackonly.css
+++ b/dist/stackonly/tablesaw.stackonly.css
@@ -1,6 +1,6 @@
-/*! Tablesaw - v3.1.2 - 2019-03-19
+/*! Tablesaw - v3.1.2 - 2020-06-19
 * https://github.com/filamentgroup/tablesaw
-* Copyright (c) 2019 Filament Group; Licensed MIT */
+* Copyright (c) 2020 Filament Group; Licensed MIT */
 
 .tablesaw {
   width: 100%;
@@ -88,7 +88,15 @@
 
   .tablesaw-stack thead td,
   .tablesaw-stack thead th {
-    display: none;
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
   }
 
   .tablesaw-stack tbody td,

--- a/dist/stackonly/tablesaw.stackonly.jquery.js
+++ b/dist/stackonly/tablesaw.stackonly.jquery.js
@@ -1,6 +1,6 @@
-/*! Tablesaw - v3.1.2 - 2019-03-19
+/*! Tablesaw - v3.1.2 - 2020-06-19
 * https://github.com/filamentgroup/tablesaw
-* Copyright (c) 2019 Filament Group; Licensed MIT */
+* Copyright (c) 2020 Filament Group; Licensed MIT */
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
     define(["jquery"], function (jQuery) {
@@ -586,7 +586,7 @@ if (Tablesaw.mustard) {
 				);
 			})
 			.each(function() {
-				var $newHeader = $(document.createElement("b")).addClass(classes.cellLabels);
+				var $newHeader = $(document.createElement("b")).addClass(classes.cellLabels).attr('aria-hidden', true);
 				var $cell = $(this);
 
 				$(self.tablesaw._findPrimaryHeadersForCell(this)).each(function(index) {

--- a/dist/stackonly/tablesaw.stackonly.js
+++ b/dist/stackonly/tablesaw.stackonly.js
@@ -1,6 +1,6 @@
-/*! Tablesaw - v3.1.2 - 2019-03-19
+/*! Tablesaw - v3.1.2 - 2020-06-19
 * https://github.com/filamentgroup/tablesaw
-* Copyright (c) 2019 Filament Group; Licensed MIT */
+* Copyright (c) 2020 Filament Group; Licensed MIT */
 /*! Shoestring - v2.0.0 - 2017-02-14
 * http://github.com/filamentgroup/shoestring/
 * Copyright (c) 2017 Scott Jehl, Filament Group, Inc; Licensed MIT & GPLv2 */ 
@@ -2287,7 +2287,7 @@ if (Tablesaw.mustard) {
 				);
 			})
 			.each(function() {
-				var $newHeader = $(document.createElement("b")).addClass(classes.cellLabels);
+				var $newHeader = $(document.createElement("b")).addClass(classes.cellLabels).attr('aria-hidden', true);
 				var $cell = $(this);
 
 				$(self.tablesaw._findPrimaryHeadersForCell(this)).each(function(index) {

--- a/dist/stackonly/tablesaw.stackonly.scss
+++ b/dist/stackonly/tablesaw.stackonly.scss
@@ -1,9 +1,9 @@
-/*! Tablesaw - v3.1.2 - 2019-03-19
+/*! Tablesaw - v3.1.2 - 2020-06-19
 * https://github.com/filamentgroup/tablesaw
-* Copyright (c) 2019 Filament Group; Licensed MIT */
-/*! Tablesaw - v3.1.2 - 2019-03-19
+* Copyright (c) 2020 Filament Group; Licensed MIT */
+/*! Tablesaw - v3.1.2 - 2020-06-19
 * https://github.com/filamentgroup/tablesaw
-* Copyright (c) 2019 Filament Group; Licensed MIT */
+* Copyright (c) 2020 Filament Group; Licensed MIT */
 
 .tablesaw {
   width: 100%;
@@ -88,7 +88,15 @@
   }
   .tablesaw-stack thead td,
   .tablesaw-stack thead th {
-    display: none;
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
   }
   .tablesaw-stack tbody td,
   .tablesaw-stack tbody th {

--- a/dist/tablesaw-init.js
+++ b/dist/tablesaw-init.js
@@ -1,6 +1,6 @@
-/*! Tablesaw - v3.1.2 - 2019-03-19
+/*! Tablesaw - v3.1.2 - 2020-06-19
 * https://github.com/filamentgroup/tablesaw
-* Copyright (c) 2019 Filament Group; Licensed MIT */
+* Copyright (c) 2020 Filament Group; Licensed MIT */
 (function(win) {
 	"use strict";
 

--- a/dist/tablesaw.css
+++ b/dist/tablesaw.css
@@ -1,6 +1,6 @@
-/*! Tablesaw - v3.1.2 - 2019-03-19
+/*! Tablesaw - v3.1.2 - 2020-06-19
 * https://github.com/filamentgroup/tablesaw
-* Copyright (c) 2019 Filament Group; Licensed MIT */
+* Copyright (c) 2020 Filament Group; Licensed MIT */
 
 .tablesaw {
   width: 100%;
@@ -425,7 +425,15 @@ a.tablesaw-btn {
 
   .tablesaw-stack thead td,
   .tablesaw-stack thead th {
-    display: none;
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
   }
 
   .tablesaw-stack tbody td,

--- a/dist/tablesaw.jquery.js
+++ b/dist/tablesaw.jquery.js
@@ -1,6 +1,6 @@
-/*! Tablesaw - v3.1.2 - 2019-03-19
+/*! Tablesaw - v3.1.2 - 2020-06-19
 * https://github.com/filamentgroup/tablesaw
-* Copyright (c) 2019 Filament Group; Licensed MIT */
+* Copyright (c) 2020 Filament Group; Licensed MIT */
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
     define(["jquery"], function (jQuery) {
@@ -586,7 +586,7 @@ if (Tablesaw.mustard) {
 				);
 			})
 			.each(function() {
-				var $newHeader = $(document.createElement("b")).addClass(classes.cellLabels);
+				var $newHeader = $(document.createElement("b")).addClass(classes.cellLabels).attr('aria-hidden', true);
 				var $cell = $(this);
 
 				$(self.tablesaw._findPrimaryHeadersForCell(this)).each(function(index) {

--- a/dist/tablesaw.js
+++ b/dist/tablesaw.js
@@ -1,6 +1,6 @@
-/*! Tablesaw - v3.1.2 - 2019-03-19
+/*! Tablesaw - v3.1.2 - 2020-06-19
 * https://github.com/filamentgroup/tablesaw
-* Copyright (c) 2019 Filament Group; Licensed MIT */
+* Copyright (c) 2020 Filament Group; Licensed MIT */
 /*! Shoestring - v2.0.0 - 2017-02-14
 * http://github.com/filamentgroup/shoestring/
 * Copyright (c) 2017 Scott Jehl, Filament Group, Inc; Licensed MIT & GPLv2 */ 
@@ -2287,7 +2287,7 @@ if (Tablesaw.mustard) {
 				);
 			})
 			.each(function() {
-				var $newHeader = $(document.createElement("b")).addClass(classes.cellLabels);
+				var $newHeader = $(document.createElement("b")).addClass(classes.cellLabels).attr('aria-hidden', true);
 				var $cell = $(this);
 
 				$(self.tablesaw._findPrimaryHeadersForCell(this)).each(function(index) {

--- a/src/tables.stack-default-breakpoint.css
+++ b/src/tables.stack-default-breakpoint.css
@@ -7,7 +7,15 @@
   }
   .tablesaw-stack thead td,
   .tablesaw-stack thead th {
-    display: none;
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
   }
   .tablesaw-stack tbody td,
   .tablesaw-stack tbody th {

--- a/src/tables.stack-mixin.scss
+++ b/src/tables.stack-mixin.scss
@@ -9,7 +9,15 @@
   }
   .tablesaw-stack thead td,
   .tablesaw-stack thead th {
-    display: none;
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
   }
   .tablesaw-stack tbody td,
   .tablesaw-stack tbody th {

--- a/src/tables.stack.js
+++ b/src/tables.stack.js
@@ -55,7 +55,9 @@
 				);
 			})
 			.each(function() {
-				var $newHeader = $(document.createElement("b")).addClass(classes.cellLabels);
+				var $newHeader = $(document.createElement("b"))
+					.addClass(classes.cellLabels)
+					.attr("aria-hidden", true);
 				var $cell = $(this);
 
 				$(self.tablesaw._findPrimaryHeadersForCell(this)).each(function(index) {


### PR DESCRIPTION
## Problem/motivation
Fixes #385 -- an accessibility issue where screen readers cannot see table headers.

## Proposed resolution
- Use Bootstrap-style screen-reader only display for table headers
rather than `display: none;`
- Append `aria-hidden="true"` to inserted cell labels, since they are
duplicative in the context of screen readers, which now can always see
table headers.